### PR TITLE
Add a "cs" file in the "Cache" directory

### DIFF
--- a/Library/PackageCache/com.unity.collab-proxy@1.5.7/Editor/PlasticSCM/AssetOverlays/Cache/BuildPathDictionary.cs
+++ b/Library/PackageCache/com.unity.collab-proxy@1.5.7/Editor/PlasticSCM/AssetOverlays/Cache/BuildPathDictionary.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Codice.Utils;
+
+namespace Unity.PlasticSCM.Editor.AssetsOverlays.Cache
+{
+    internal static class BuildPathDictionary
+    {
+        internal static Dictionary<string, T> ForPlatform<T>()
+        {
+            if (PlatformIdentifier.IsWindows())
+                return new Dictionary<string, T>(
+                    StringComparer.OrdinalIgnoreCase);
+
+            return new Dictionary<string, T>();
+        }
+    }
+}


### PR DESCRIPTION
Add "BuildPathDictionary.cs" file in the "\Editor\PlasticSCM\AssetOverlays\Cache" directory.